### PR TITLE
Fix inverted success/failure logic in evaluate.js

### DIFF
--- a/css_browserhook.py
+++ b/css_browserhook.py
@@ -47,7 +47,7 @@ class BrowserTabHook:
                 if "value" in res["result"]["result"]:
                     res = res["result"]["result"]["value"]
                 elif "type" in res["result"]["result"] and res["result"]["result"]["type"] == "undefined":
-                    res = "Undefined"
+                    res = None
                 else:
                     res = None
             else:


### PR DESCRIPTION
Fixes #126

Problem: evaluate_js in css_browserhook.py does not check exceptionDetails in the DevTools Runtime.evaluate response. When JavaScript throws an exception, the code falls through to res = None. In commit_css_transaction, if res is None: return res treats this as success. Meanwhile, successful execution returns "Undefined" (a string), which triggers the retry loop as a failure. Success and failure are completely inverted.

Result: CSS injection silently fails on every attempt. Logs show “Committing css transaction” with no errors, but nothing renders in the Steam UI.

Fix: Change res = "Undefined" to res = None so successful execution correctly signals success to commit_css_transaction.

Tested on: SteamOS 3.7.25, Decky v3.2.3, CSS Loader 2.1.2
